### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 [![MseeP.ai Security Assessment Badge](https://mseep.net/pr/rendyfebry-google-pse-mcp-badge.png)](https://mseep.ai/app/rendyfebry-google-pse-mcp)
 
+<a href="https://glama.ai/mcp/servers/@rendyfebry/google-pse-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rendyfebry/google-pse-mcp/badge" alt="Google PSE Server MCP server" />
+</a>
+
 # Google Programmable Search Engine (PSE) MCP Server
 
 A Model Context Protocol (MCP) server for the Google Programmable Search Engine (PSE) API. This server exposes tools for searching the web with Google Custom Search engine, making them accessible to MCP-compatible clients such as VSCode, Copilot, and Claude Desktop.


### PR DESCRIPTION
This PR adds a badge for the [Google PSE MCP Server](https://glama.ai/mcp/servers/@rendyfebry/google-pse-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@rendyfebry/google-pse-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@rendyfebry/google-pse-mcp/badge" alt="Google PSE Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.